### PR TITLE
Add flux unit matching to uvcombine

### DIFF
--- a/uvcombine/uvcombine.py
+++ b/uvcombine/uvcombine.py
@@ -117,6 +117,8 @@ def match_flux_units(image, image_header, target_header):
         raise ValueError("Jy/pixel is not an accepted unit to convert into "
                          "since it is dependent on the pixel size.  Try Jy/"
                          "sr instead?")
+    else:
+        target_header_unit = target_unit.to_string('FITS')
 
     # do this as a separate if statement because we may have converted
     # Jy/beam->Jy/sr above
@@ -130,8 +132,6 @@ def match_flux_units(image, image_header, target_header):
         elif image_unit.is_equivalent(u.Jy/u.pixel):
             pixel_area = wcs.utils.proj_plane_pixel_area(im_wcs)*u.deg**2
             image_unit = image_unit.bases[0] / pixel_area
-
-    log.debug("image beam: {0}  target_beam: {1}".format(image_beam, target_beam))
 
     log.info("Converting data from {0} to {1}".format(image_unit, target_unit))
     image = u.Quantity(image, image_unit).to(target_unit, equivalency)

--- a/uvcombine/uvcombine.py
+++ b/uvcombine/uvcombine.py
@@ -63,8 +63,31 @@ def file_in(filename, extnum=0):
 
 def match_flux_units(image, image_header, target_header):
     """
-    Match the flux units of the input image to the target header
+    Match the flux units of the input image to the target header.  There are
+    significant restrictions on the allowed units in the image and target
+    headers.
+
+    Parameters
+    ----------
+    image : array
+        An array of flux density or surface brightness units
+    image_header : fits.Header
+        The header associated with the above array
+    target_header : fits.Header
+        The header whose units should be matched
+
+    Returns
+    -------
+    new_image : array
+        The array in the new units
+    new_header : fits.Header
+        The corresponding FITS header that specifies the appropriate units
+        (including the beam area if the appropriate unit is Jy/beam)
     """
+
+    # copy because we're modifying this and we don't want to inplace modify the
+    # object ever
+    image_header = image_header.copy()
 
     if 'BUNIT' not in image_header:
         raise ValueError("Image header must have a BUNIT specified")


### PR DESCRIPTION
`feather_simple` had previously assumed both images were in equivalent
brightness units (e.g., K or MJy/sr).  The new module will convert to Jy/beam or Jy/sr or K.
I didn't include Jy/pixel, since that's a technically very weird unit since we
are regridding at a later step; it should actually be fine to convert to
Jy/pixel (where "pixel" really means "area of a pixel in the high-resolution
data set").