### PR TITLE
Add cube feathering simple function loop and consistency tests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,12 +24,14 @@ install_requires =
 test =
     pytest-astropy
     pytest-cov
+    scikit-image
 docs =
     sphinx-astropy
     matplotlib
 all =
     statsmodels
     matplotlib
+    scikit-image
 
 [options.package_data]
 uvcombine.tests =

--- a/uvcombine/conftest.py
+++ b/uvcombine/conftest.py
@@ -56,7 +56,7 @@ def plaw_test_data():
                                 largest_scale=56. * units.arcsec,
                                 smallest_scale=3. * units.arcsec,
                                 lowresfwhm=25. * units.arcsec,
-                                pixel_scale=1 * units.arcsec,
+                                pixel_scale=3 * units.arcsec,
                                 imsize=512)
 
     # angscales, ratios, lowres_pts, highres_pts = out
@@ -71,7 +71,7 @@ def plaw_test_cube_sc():
                              largest_scale=56. * units.arcsec,
                              smallest_scale=3. * units.arcsec,
                              lowresfwhm=25. * units.arcsec,
-                             pixel_scale=1 * units.arcsec,
+                             pixel_scale=3 * units.arcsec,
                              imsize=512,
                              nchan=3)
 
@@ -86,7 +86,7 @@ def plaw_test_cube_hdu():
                              largest_scale=56. * units.arcsec,
                              smallest_scale=3. * units.arcsec,
                              lowresfwhm=25. * units.arcsec,
-                             pixel_scale=1 * units.arcsec,
+                             pixel_scale=3 * units.arcsec,
                              imsize=512,
                              nchan=3)
 

--- a/uvcombine/tests/test_feather.py
+++ b/uvcombine/tests/test_feather.py
@@ -40,7 +40,7 @@ def test_feather_simple(plaw_test_data):
     # Test against normalized_root_mse using the Euclidean metric
     # Roughly a fractional difference using the feathered data as source of "error"
     nmse = normalized_root_mse(orig_data, combo.real, normalization='euclidean')
-    assert nmse < 1e-1
+    assert nmse < 3e-2
 
     # Test against structural similarity metric
     ssim = structural_similarity(orig_data, combo.real)

--- a/uvcombine/tests/test_feather.py
+++ b/uvcombine/tests/test_feather.py
@@ -44,7 +44,7 @@ def test_feather_simple(plaw_test_data):
 
     # Test against structural similarity metric
     ssim = structural_similarity(orig_data, combo.real)
-    assert ssim > 0.8
+    assert ssim > 0.99
 
 
 @pytest.mark.parametrize(('lounit', 'hiunit'),

--- a/uvcombine/tests/test_feather.py
+++ b/uvcombine/tests/test_feather.py
@@ -177,3 +177,27 @@ def test_feather_simple_cube_diffunits(plaw_test_cube_sc):
     # Test against flux recovery
     frac_diff = (orig_cube - combo_cube_sc_smunits).sum() / orig_cube.sum()
     npt.assert_allclose(0., frac_diff, atol=5e-3)
+
+
+def test_feather_cube_consistency(plaw_test_cube_sc):
+    '''
+    Before fourier_combine_cubes is fully deprecated, check consistency
+    with the output from feather_simple_cubes.
+    '''
+
+    orig_cube, sd_cube, interf_cube = plaw_test_cube_sc
+
+    combo_cube_sc = feather_simple_cube(interf_cube, sd_cube)
+
+    combo_cube_fcc = fourier_combine_cubes(interf_cube, sd_cube, return_hdu=True)
+    combo_cube_fcc_sc = SpectralCube.read(combo_cube_fcc)
+
+    assert orig_cube.shape == combo_cube_sc.shape
+
+    assert combo_cube_sc.unit == interf_cube.unit
+
+    diff_cube = (combo_cube_sc - combo_cube_fcc_sc) / combo_cube_sc
+
+    assert diff_cube.max().value < 1e-10
+    assert np.abs(diff_cube.min().value) < 1e-10
+

--- a/uvcombine/tests/test_feather.py
+++ b/uvcombine/tests/test_feather.py
@@ -6,7 +6,8 @@ import numpy.testing as npt
 import numpy as np
 from spectral_cube import Projection, SpectralCube
 
-from ..uvcombine import feather_simple, fourier_combine_cubes
+from ..uvcombine import (feather_simple, fourier_combine_cubes,
+                         feather_simple_cube)
 
 
 def test_feather_simple(plaw_test_data):
@@ -57,6 +58,31 @@ def test_feather_simple_cube_diffunits(plaw_test_cube_sc):
     combo_cube = fourier_combine_cubes(interf_cube, sd_cube, return_hdu=True)
 
     combo_cube_sc = SpectralCube.read(combo_cube)
+
+    assert orig_cube.shape == combo_cube_sc.shape
+
+    # Output units should in the units of the interferometer cube
+    assert combo_cube_sc.unit == interf_cube.unit
+
+
+def test_feather_simple_cube(plaw_test_cube_sc):
+
+    orig_cube, sd_cube, interf_cube = plaw_test_cube_sc
+
+    combo_cube_sc = feather_simple_cube(interf_cube, sd_cube)
+
+    assert orig_cube.shape == combo_cube_sc.shape
+
+    assert combo_cube_sc.unit == interf_cube.unit
+
+
+def test_feather_simple_cube_diffunits(plaw_test_cube_sc):
+
+    orig_cube, sd_cube, interf_cube = plaw_test_cube_sc
+
+    interf_cube = interf_cube.to(u.Jy / u.beam)
+
+    combo_cube_sc = feather_simple_cube(interf_cube, sd_cube)
 
     assert orig_cube.shape == combo_cube_sc.shape
 

--- a/uvcombine/tests/test_feather.py
+++ b/uvcombine/tests/test_feather.py
@@ -24,6 +24,16 @@ def test_feather_simple(plaw_test_data):
 
     combo = feather_simple(highres_proj, lowres_proj)
 
+    # Assert the combined data is sufficiently close to the original
+    orig_data = orig_hdu.data
+
+    # This won't work on a pixel basis as we can't exclude outliers
+    # npt.assert_allclose(orig_data, combo.real)
+
+    # Test against flux recovery
+    frac_diff = (orig_data - combo.real).sum() / orig_data.sum()
+    npt.assert_allclose(0., frac_diff, atol=5e-3)
+
 
 def test_feather_simple_mismatchunit(plaw_test_data):
 
@@ -36,7 +46,7 @@ def test_feather_simple_mismatchunit(plaw_test_data):
         combo = feather_simple(highres_hdu, lowres_hdu, match_units=False)
 
 
-def test_feather_simple_cube(plaw_test_cube_sc):
+def test_fourier_combine_cubes(plaw_test_cube_sc):
 
     orig_cube, sd_cube, interf_cube = plaw_test_cube_sc
 
@@ -48,8 +58,12 @@ def test_feather_simple_cube(plaw_test_cube_sc):
 
     assert combo_cube_sc.unit == interf_cube.unit
 
+    # Test against flux recovery
+    frac_diff = (orig_cube - combo_cube_sc).sum() / orig_cube.sum()
+    npt.assert_allclose(0., frac_diff, atol=5e-3)
 
-def test_feather_simple_cube_diffunits(plaw_test_cube_sc):
+
+def test_fourier_combine_cubes_diffunits(plaw_test_cube_sc):
 
     orig_cube, sd_cube, interf_cube = plaw_test_cube_sc
 
@@ -64,6 +78,12 @@ def test_feather_simple_cube_diffunits(plaw_test_cube_sc):
     # Output units should in the units of the interferometer cube
     assert combo_cube_sc.unit == interf_cube.unit
 
+    combo_cube_sc_smunits = combo_cube_sc.to(orig_cube.unit)
+
+    # Test against flux recovery
+    frac_diff = (orig_cube - combo_cube_sc_smunits).sum() / orig_cube.sum()
+    npt.assert_allclose(0., frac_diff, atol=5e-3)
+
 
 def test_feather_simple_cube(plaw_test_cube_sc):
 
@@ -74,6 +94,10 @@ def test_feather_simple_cube(plaw_test_cube_sc):
     assert orig_cube.shape == combo_cube_sc.shape
 
     assert combo_cube_sc.unit == interf_cube.unit
+
+    # Test against flux recovery
+    frac_diff = (orig_cube - combo_cube_sc).sum() / orig_cube.sum()
+    npt.assert_allclose(0., frac_diff, atol=5e-3)
 
 
 def test_feather_simple_cube_diffunits(plaw_test_cube_sc):
@@ -88,3 +112,9 @@ def test_feather_simple_cube_diffunits(plaw_test_cube_sc):
 
     # Output units should in the units of the interferometer cube
     assert combo_cube_sc.unit == interf_cube.unit
+
+    combo_cube_sc_smunits = combo_cube_sc.to(orig_cube.unit)
+
+    # Test against flux recovery
+    frac_diff = (orig_cube - combo_cube_sc_smunits).sum() / orig_cube.sum()
+    npt.assert_allclose(0., frac_diff, atol=5e-3)

--- a/uvcombine/uvcombine.py
+++ b/uvcombine/uvcombine.py
@@ -432,7 +432,7 @@ def feather_simple_cube(hires, lores, **kwargs):
         feath = feather_simple(hslc.hdu, lslc.hdu)
         feathcube.append(feath)
 
-    newcube = SpectralCube(data=np.array(feathcube), header=hires.header,
+    newcube = SpectralCube(data=np.array(feathcube).real, header=hires.header,
             wcs=hires.wcs)
 
     return newcube

--- a/uvcombine/uvcombine.py
+++ b/uvcombine/uvcombine.py
@@ -1014,6 +1014,7 @@ def feather_simple_cube(hires, lores,
     return newcube
 
 
+@deprecated("2021", message="Use feather_simple_cube.")
 def fourier_combine_cubes(cube_hi, cube_lo,
                           highresscalefactor=1.0,
                           lowresscalefactor=1.0, lowresfwhm=1*u.arcmin,
@@ -1026,10 +1027,10 @@ def fourier_combine_cubes(cube_hi, cube_lo,
 
     Parameters
     ----------
-    cube_hi : SpectralCube
-    highresfitsfile : str
-        The high-resolution FITS file
-    cube_lo : SpectralCube
+    cube_hi : SpectralCube or str
+        The high-resolution spectral-cube or name of FITS file.
+    cube_lo : SpectralCube or str
+        The low-resolution spectral-cube or name of FITS file.
     highresscalefactor : float
         A factor to multiply the high-resolution data by to match the
         low- or high-resolution data

--- a/uvcombine/uvcombine.py
+++ b/uvcombine/uvcombine.py
@@ -15,7 +15,7 @@ from astropy.convolution import convolve_fft, Gaussian2DKernel
 from astropy.utils import deprecated
 
 
-@deprecated("2021")
+@deprecated("2022")
 def file_in(filename, extnum=0):
     """
     Take the input files. If input is already HDU, then return it.
@@ -66,7 +66,7 @@ def file_in(filename, extnum=0):
 # NOTE: this SHOULD work for all 2D images in brightness units.
 # Hybrid integrated moment maps will not (and I don't think that's a realistic use
 # case).
-@deprecated("2021", message='Use Projection.to for unit conversion.')
+@deprecated("2022", message='Use Projection.to for unit conversion.')
 def match_flux_units(image, image_header, target_header):
     """
     Match the flux units of the input image to the target header.  There are
@@ -169,7 +169,7 @@ def match_flux_units(image, image_header, target_header):
 
     return image, image_header
 
-@deprecated("2021", message="Use Projection.reproject (2D).")
+@deprecated("2022", message="Use Projection.reproject (2D).")
 def regrid(hd1, im1, im2raw, hd2):
     """
     Regrid the low resolution image to have the same dimension and pixel size with the
@@ -847,7 +847,7 @@ def feather_plot(hires, lores,
            }
 
 
-@deprecated("2021", message="Instead use SpectralCube.spectral_interpolate")
+@deprecated("2022", message="Instead use SpectralCube.spectral_interpolate")
 def spectral_regrid(cube, outgrid):
     """
     Spectrally regrid a cube onto a new spectral output grid
@@ -916,7 +916,7 @@ def spectral_regrid(cube, outgrid):
     return fits.PrimaryHDU(data=newcube, header=newheader)
 
 
-@deprecated("2021", message="Use SpectralCube.spectral_smooth and SpectralCube.downsample_axis instead")
+@deprecated("2022", message="Use SpectralCube.spectral_smooth and SpectralCube.downsample_axis instead")
 def spectral_smooth_and_downsample(cube, kernelfwhm):
     """
     Smooth the cube along the spectral axis by a specific Gaussian kernel, then
@@ -1014,7 +1014,7 @@ def feather_simple_cube(hires, lores,
     return newcube
 
 
-@deprecated("2021", message="Use feather_simple_cube.")
+@deprecated("2022", message="Use feather_simple_cube.")
 def fourier_combine_cubes(cube_hi, cube_lo,
                           highresscalefactor=1.0,
                           lowresscalefactor=1.0, lowresfwhm=1*u.arcmin,

--- a/uvcombine/uvcombine.py
+++ b/uvcombine/uvcombine.py
@@ -423,6 +423,10 @@ def feather_simple_cube(hires, lores, **kwargs):
 
       * Can we paralellize, daskify, or otherwise not-in-memory-ify this?
     """
+
+    if lores.shape[0]!=hires.shape[0] or not all(lores.spectral_axis == hires.spectral_axis):
+        lores = lores.spectral_interpolate(hires.spectral_axis)
+
     feathcube = []
     for hslc, lslc in zip(hires, lores):
         feath = feather_simple(hslc.hdu, lslc.hdu)

--- a/uvcombine/uvcombine.py
+++ b/uvcombine/uvcombine.py
@@ -1034,7 +1034,8 @@ def feather_simple_cube(cube_hi, cube_lo,
 @deprecated("2022", message="Use feather_simple_cube.")
 def fourier_combine_cubes(cube_hi, cube_lo,
                           highresscalefactor=1.0,
-                          lowresscalefactor=1.0, lowresfwhm=1*u.arcmin,
+                          lowresscalefactor=1.0,
+                          lowresfwhm=None,
                           return_regridded_cube_lo=False,
                           return_hdu=True,
                           maximum_cube_size=1e8,
@@ -1073,6 +1074,11 @@ def fourier_combine_cubes(cube_hi, cube_lo,
     if cube_hi.size > maximum_cube_size:
         raise ValueError("Cube is probably too large "
                          "for this operation to work in memory")
+
+    if lowresfwhm is None:
+        beam_low = cube_lo.beam
+        lowresfwhm = beam_low.major
+
 
     im_hi = cube_hi._data # want the raw data for this
     hd_hi = cube_hi.header

--- a/uvcombine/uvcombine.py
+++ b/uvcombine/uvcombine.py
@@ -412,39 +412,6 @@ def simple_fourier_unsharpmask(hdu, lowresfwhm, minval=1e-1):
 
     return umask_hi
 
-def feather_simple_cube(hires, lores, **kwargs):
-    """
-    Parameters
-    ----------
-    hires : cube
-    lores : cube
-
-    TODO:
-
-      * Can we paralellize, daskify, or otherwise not-in-memory-ify this?
-    """
-
-    if not hasattr(hires, shape):
-        hires = SpectralCube.read(hires)
-    if not hasattr(hires, shape):
-        lores = SpectralCube.read(lores)
-
-    if lores.shape[0]!=hires.shape[0] or not all(lores.spectral_axis == hires.spectral_axis):
-        lores = lores.spectral_interpolate(hires.spectral_axis)
-
-    feathcube = []
-    pb = ProgressBar(len(hires))
-    for hslc, lslc in zip(hires, lores):
-        feath = feather_simple(hslc.hdu, lslc.hdu)
-        feathcube.append(feath)
-        pb.update()
-
-    newcube = SpectralCube(data=np.array(feathcube).real, header=hires.header,
-            wcs=hires.wcs)
-
-    return newcube
-
-
 def feather_simple(hires, lores,
                    highresextnum=0,
                    lowresextnum=0,

--- a/uvcombine/uvcombine.py
+++ b/uvcombine/uvcombine.py
@@ -424,13 +424,20 @@ def feather_simple_cube(hires, lores, **kwargs):
       * Can we paralellize, daskify, or otherwise not-in-memory-ify this?
     """
 
+    if not hasattr(hires, shape):
+        hires = SpectralCube.read(hires)
+    if not hasattr(hires, shape):
+        lores = SpectralCube.read(lores)
+
     if lores.shape[0]!=hires.shape[0] or not all(lores.spectral_axis == hires.spectral_axis):
         lores = lores.spectral_interpolate(hires.spectral_axis)
 
     feathcube = []
+    pb = ProgressBar(len(hires))
     for hslc, lslc in zip(hires, lores):
         feath = feather_simple(hslc.hdu, lslc.hdu)
         feathcube.append(feath)
+        pb.update()
 
     newcube = SpectralCube(data=np.array(feathcube).real, header=hires.header,
             wcs=hires.wcs)

--- a/uvcombine/uvcombine.py
+++ b/uvcombine/uvcombine.py
@@ -993,7 +993,7 @@ def feather_simple_cube(hires, lores, **kwargs):
     feathcube = []
     pb = ProgressBar(len(hires))
     for hslc, lslc in zip(hires, lores):
-        feath = feather_simple(hslc.hdu, lslc.hdu)
+        feath = feather_simple(hslc.hdu, lslc.hdu, **kwargs)
         feathcube.append(feath)
         pb.update()
 

--- a/uvcombine/uvcombine.py
+++ b/uvcombine/uvcombine.py
@@ -412,6 +412,27 @@ def simple_fourier_unsharpmask(hdu, lowresfwhm, minval=1e-1):
 
     return umask_hi
 
+def feather_simple_cube(hires, lores, **kwargs):
+    """
+    Parameters
+    ----------
+    hires : cube
+    lores : cube
+
+    TODO:
+
+      * Can we paralellize, daskify, or otherwise not-in-memory-ify this?
+    """
+    feathcube = []
+    for hslc, lslc in zip(hires, lores):
+        feath = feather_simple(hslc.hdu, lslc.hdu)
+        feathcube.append(feath)
+
+    newcube = SpectralCube(data=np.array(feathcube), header=hires.header,
+            wcs=hires.wcs)
+
+    return newcube
+
 
 def feather_simple(hires, lores,
                    highresextnum=0,

--- a/uvcombine/uvcombine.py
+++ b/uvcombine/uvcombine.py
@@ -975,6 +975,7 @@ def spectral_smooth_and_downsample(cube, kernelfwhm):
 
 def feather_simple_cube(cube_hi, cube_lo,
                         allow_spectral_resample=True,
+                        allow_huge_operations=False,
                         **kwargs):
     """
     Parameters
@@ -988,6 +989,10 @@ def feather_simple_cube(cube_hi, cube_lo,
         of the data. Note that spectral smoothing may need to be first applied when downsampling
         along the spectral axis; this should be applied to the input data prior to feathering.
         If False, a ValueError is raised when the spectral axes of the cubes differ.
+    allow_huge_operations : bool
+        Sets `~spectral_cube.SpectralCube.allow_huge_operations`. If True, no memory related
+        errors will be raise prior to computing. If False, an error will be raise if the cube
+        size is too large (currently set to ~1 GB in spectral-cube).
     kwargs : Passed to `~feather_simple`.
 
     Returns
@@ -1003,6 +1008,9 @@ def feather_simple_cube(cube_hi, cube_lo,
         cube_hi = SpectralCube.read(cube_hi)
     if not hasattr(cube_lo, 'shape'):
         cube_lo = SpectralCube.read(cube_lo)
+
+    cube_hi.allow_huge_operations = allow_huge_operations
+    cube_lo.allow_huge_operations = allow_huge_operations
 
     if cube_lo.shape[0]!=cube_hi.shape[0] or not all(cube_lo.spectral_axis == cube_hi.spectral_axis):
         if allow_spectral_resample:


### PR DESCRIPTION
Compare to:

`fourier_combine_cubes`: assumes a single kernel for the whole cube


Lots of outstanding problems:

- [ ] currently only works in memory
- [ ] needs spectral regridding prior to loop (critical!)

