### PR TITLE
Set up PyPI Trusted Publishing, add missing LICENSE

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,36 +1,49 @@
 name: Build and upload to PyPI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - main
+    tags:
+    - '*'
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   build_sdist_and_wheel:
-    name: Build source distribution
+    name: Build distribution
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+      - uses: actions/setup-python@v5
         name: Install Python
         with:
-          python-version: '3.9'
+          python-version: '3.12'
       - name: Install build
         run: python -m pip install build
-      - name: Build sdist
+      - name: Build sdist and wheel
         run: python -m build --sdist --wheel --outdir dist/ .
       - uses: actions/upload-artifact@v4
         with:
+          name: dist
           path: dist/*
 
   upload_pypi:
     name: Upload to PyPI
     needs: [build_sdist_and_wheel]
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    environment:
+      name: pypi
+      url: https://pypi.org/p/uvcombine
+    permissions:
+      id-token: write  # required for PyPI trusted publishing (OIDC)
     steps:
-      - uses: actions/download-artifact@v4.1.7
+      - uses: actions/download-artifact@v4
         with:
-          name: artifact
+          name: dist
           path: dist
-      - uses: pypa/gh-action-pypi-publish@master
-        with:
-          user: __token__
-          password: ${{ secrets.pypi_password }}
+      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/LICENSE.rst
+++ b/LICENSE.rst
@@ -1,0 +1,27 @@
+Copyright (c) 2015-2026, uvcombine developers
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,9 @@ dev = [
     "spectral-cube>=0.0.dev0",
     "radio-beam>=0.0.dev0",
 ]
+all = [
+  "uvcombine[test,docs]",
+]
 
 [project.urls]
 homepage = "https://uvcombine.readthedocs.org"

--- a/uvcombine/tests/test_casa.py
+++ b/uvcombine/tests/test_casa.py
@@ -19,7 +19,7 @@ except ImportError:
 from .. import feather_simple
 
 @pytest.mark.skipif('not casa_imported')
-@pytest.mark.parametrize(('sdfactor', 'lowpassfilterSD'), itertools.product((0.5, 1, 1.5), (True,False)))
+@pytest.mark.parametrize(('sdfactor', 'lowpassfilterSD'), list(itertools.product((0.5, 1, 1.5), (True,False))))
 def test_casafeather(image_sz512as_pl1p5_fwhm2as_scale1as, sdfactor, lowpassfilterSD):
 
     tmp_path, input_fn, intf_fn, sd_fn = image_sz512as_pl1p5_fwhm2as_scale1as


### PR DESCRIPTION
## Summary
- Switch `publish.yml` to PyPI Trusted Publishing (OIDC): drop the username/password auth, add `id-token: write` and a `pypi` GitHub environment, modernize/pin the actions, and fetch tags so `setuptools_scm` resolves the release version correctly on tag builds.
- Add the `LICENSE.rst` referenced by `MANIFEST.in` and `pyproject.toml`'s `license` field, which was missing from the repo.

A pending publisher for `radio-astro-tools/uvcombine` / `publish.yml` / environment `pypi` has already been registered on PyPI, so once this merges, pushing a `v*` tag will create the `uvcombine` project on PyPI and publish the release — no stored secrets needed.

## Test plan
- [x] `python -m build --sdist --wheel` succeeds locally
- [x] `twine check` passes on both the sdist and wheel
- [ ] Push a `v*` tag after merge and confirm the `upload_pypi` job publishes successfully via the pending trusted publisher
