### PR TITLE
Fix CI: pytest 9 parametrize error and missing 'all' extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,9 @@ dev = [
     "spectral-cube>=0.0.dev0",
     "radio-beam>=0.0.dev0",
 ]
+all = [
+  "uvcombine[test,docs]",
+]
 
 [project.urls]
 homepage = "https://uvcombine.readthedocs.org"

--- a/uvcombine/tests/test_casa.py
+++ b/uvcombine/tests/test_casa.py
@@ -19,7 +19,7 @@ except ImportError:
 from .. import feather_simple
 
 @pytest.mark.skipif('not casa_imported')
-@pytest.mark.parametrize(('sdfactor', 'lowpassfilterSD'), itertools.product((0.5, 1, 1.5), (True,False)))
+@pytest.mark.parametrize(('sdfactor', 'lowpassfilterSD'), list(itertools.product((0.5, 1, 1.5), (True,False))))
 def test_casafeather(image_sz512as_pl1p5_fwhm2as_scale1as, sdfactor, lowpassfilterSD):
 
     tmp_path, input_fn, intf_fn, sd_fn = image_sz512as_pl1p5_fwhm2as_scale1as


### PR DESCRIPTION
## Summary
Two pre-existing bugs were failing the entire test matrix on `main` (unrelated to any specific feature — surfaced because CI floats to latest dependency versions):

- pytest 9 turns the "non-Collection iterable passed to `parametrize`" deprecation warning into a hard collection error, because this repo's `filterwarnings` config elevates `DeprecationWarning` to an error. `test_casa.py` passed a raw `itertools.product(...)` to `parametrize`; wrapped it in `list(...)`.
- `tox.ini`'s `*-test-all` environments request the `all` extra (`all: all`), which `pyproject.toml` never defined. Newer pip/tox treat a missing extra as a hard error instead of a warning. Added an `all` optional-dependency extra aliasing to `[test,docs]`.

## Test plan
- [x] Confirmed both failure signatures against the currently-failing CI runs on #51 and #52 before fixing
- [ ] CI green on this PR
