### PR TITLE
Handle unitless axes in feather_plot

### DIFF
--- a/uvcombine/tests/test_feather.py
+++ b/uvcombine/tests/test_feather.py
@@ -12,7 +12,17 @@ from skimage.metrics import structural_similarity, normalized_root_mse
 
 from . import path
 
-from ..uvcombine import (feather_simple, feather_simple_cube)
+from ..uvcombine import (_plot_axis_limits, feather_simple, feather_simple_cube)
+
+
+@pytest.mark.parametrize("xaxis", (
+    np.array([10., 20., 30.]),
+    np.array([10., 20., 30.]) * u.arcsec,
+))
+def test_plot_axis_limits(xaxis):
+    xlim = _plot_axis_limits(xaxis, arg_xmin=2)
+
+    npt.assert_allclose(xlim, (30. / 1.1, 20. * 1.1))
 
 
 def cube_and_raw(filename, use_dask=None):

--- a/uvcombine/uvcombine.py
+++ b/uvcombine/uvcombine.py
@@ -15,6 +15,12 @@ from astropy.convolution import convolve_fft, Gaussian2DKernel
 from spectral_cube.dask_spectral_cube import DaskSpectralCube, DaskVaryingResolutionSpectralCube
 
 
+def _plot_axis_limits(xaxis, arg_xmin):
+    """Return numeric plot limits for unitless or Quantity-like axes."""
+    values = np.asarray(xaxis)
+    return values[arg_xmin] / 1.1, values[1] * 1.1
+
+
 def feather_kernel(nax2, nax1, lowresfwhm, pixscale):
     """
     Construct the weight kernels (image arrays) for the fourier transformed low
@@ -578,7 +584,7 @@ def feather_plot(hires, lores,
     ax1.set_ylim(1e-5, 1.1)
 
     arg_xmin = np.nanargmin(np.abs((azavg_ikernel)-(1-1e-5)))
-    xlim = xaxis[arg_xmin].value / 1.1, xaxis[1].value * 1.1
+    xlim = _plot_axis_limits(xaxis, arg_xmin)
     log.debug("Xlim: {0}".format(xlim))
     assert np.isfinite(xlim[0])
     assert np.isfinite(xlim[1])


### PR DESCRIPTION
## Summary

- convert `feather_plot` x-axis data to plain numeric values before computing limits
- support both Astropy `Quantity` axes and NumPy arrays without assuming `.value`
- add regression coverage for both input forms

Fixes #49.

## Testing

- `python -m pytest uvcombine/tests/test_feather.py -q` — 29 passed
- `python -m pytest uvcombine/tests --ignore=uvcombine/tests/test_casa.py -q` — 32 passed, 1 skipped

`test_casa.py` is excluded from the full local run because its existing iterator-based parametrization raises `PytestRemovedIn10Warning` under pytest 9 during collection.