### PR TITLE
Fix stale docs and add coverage for feather_plot/feather_compare

### DIFF
--- a/docs/diagnostics.rst
+++ b/docs/diagnostics.rst
@@ -1,0 +1,52 @@
+.. _diagnostics:
+
+Diagnostics and consistency checks
+===================================
+
+Before (or after) feathering two images, it is useful to check that the
+high- and low-resolution data agree with each other over the range of
+spatial scales where their uv-coverage overlaps. uvcombine provides two
+functions for this.
+
+Comparing flux scales in the uv-overlap region
+------------------------------------------------
+
+`~uvcombine.feather_compare` compares the Fourier amplitudes of the
+high- and low-resolution data over a user-specified range of angular
+scales (the region where both data sets should be sensitive to the same
+structures), and reports the ratio between them. A ratio far from 1
+indicates a flux-scale mismatch between the two data sets that should be
+corrected (for example with ``lowresscalefactor``/``highresscalefactor``
+in `~uvcombine.feather_simple`) before feathering::
+
+    >>> from uvcombine import feather_compare
+    >>> from astropy import units as u
+    >>> stats = feather_compare(highres_image, lowres_image,  # doctest: +SKIP
+    ...                          SAS=5 * u.arcsec, LAS=30 * u.arcsec,
+    ...                          lowresfwhm=30 * u.arcsec)
+
+``SAS`` and ``LAS`` set the smallest and largest angular scales to
+include in the comparison; ``LAS`` should typically correspond to the
+largest angular scale recoverable by the interferometric data. By
+default a diagnostic plot is produced (``doplot=True``); set
+``return_samples=True`` to instead get back the individual per-pixel
+samples (angular scale, ratio, and high-/low-resolution amplitudes) in
+the overlap region rather than the summary statistics.
+
+Plotting the power spectra
+---------------------------
+
+`~uvcombine.feather_plot` plots the azimuthally-averaged power spectra
+of the high- and low-resolution images together with the feathering
+weight kernels, which is useful for visually inspecting where the two
+data sets are combined and how much weight each contributes as a
+function of spatial scale::
+
+    >>> from uvcombine import feather_plot
+    >>> results = feather_plot(highres_image, lowres_image)  # doctest: +SKIP
+
+It accepts the same ``lowresfwhm``, ``lowresscalefactor``,
+``highresscalefactor``, and ``lowpassfilterSD`` options as
+`~uvcombine.feather_simple` (see :ref:`featherimages`), plus
+``hires_threshold``/``lores_threshold`` to exclude noise-dominated
+pixels below a given value before computing the power spectra.

--- a/docs/diagnostics.rst
+++ b/docs/diagnostics.rst
@@ -33,6 +33,10 @@ default a diagnostic plot is produced (``doplot=True``); set
 samples (angular scale, ratio, and high-/low-resolution amplitudes) in
 the overlap region rather than the summary statistics.
 
+`ScaleFactors.ipynb <https://github.com/radio-astro-tools/uvcombine/blob/main/examples/ScaleFactors.ipynb>`_
+compares several methods for finding this scale factor from the
+uv-overlap region.
+
 Plotting the power spectra
 ---------------------------
 

--- a/docs/feathering_cubes.rst
+++ b/docs/feathering_cubes.rst
@@ -74,10 +74,9 @@ If the cubes already have matching chunk size, you can avoid rechunking the cube
 Previous functionality
 ----------------------
 
-A similar function `~uvcombine.fourier_combine_cubes` was previously implemented
-in uvcombine. Its use is now depcrecated as it lacks new features implemented in
-`~uvcombine.feather_simple_cube`. This method is appropriate for two cubes that each
-have a single beam size (i.e., the beam does not change between spectral channels).
-The low resolution beam size is also set using `lowresfwhm`, and is NOT read from
-the FITS header.
+Earlier versions of uvcombine provided a separate ``fourier_combine_cubes``
+function for feathering two cubes. It has been removed; use
+`~uvcombine.feather_simple_cube` instead, which covers the same use case
+(cubes with a single beam that does not change between channels) plus
+varying-resolution and dask-based cubes.
 

--- a/docs/feathering_images.rst
+++ b/docs/feathering_images.rst
@@ -20,6 +20,8 @@ In the simplest case, a low- and high-resolution image can be feathered with::
 
 The defaults settings in `~uvcombine.feather_simple` match those used by CASA's
 `feather task <https://casadocs.readthedocs.io/en/stable/api/tt/casatasks.imaging.feather.html>`_.
+A worked comparison against CASA's own ``feather`` task is available in
+`example_uvcombine_casa_feather_comparison.py <https://github.com/radio-astro-tools/uvcombine/blob/main/examples/example_uvcombine_casa_feather_comparison.py>`_.
 
 `~uvcombine.feather_simple` has many options to alter the handling, uv-cutoff, or weighting of the two
 images when combining.
@@ -29,9 +31,15 @@ images when combining.
 * ``lowresfwhm`` overrides the beam size in the low resolution data.
 * ``lowpassfilterSD`` filters high spatial frequenceis in the low resolution image by its beam. Similar to ``lowpassfiltersd`` in CASA.
 * ``replace_hires`` will replace the high spatial frequencies of the feathered image above a set threshold in the low resolution beam kernel, rather than combining by the weighting kernel.
-* ``deconvSD`` will deconvolve the low resolution data by its beam before combining the data.
+* ``deconvSD`` will deconvolve the low resolution data by its beam before combining the data. See
+  `DeconvolutionTests.ipynb <https://github.com/radio-astro-tools/uvcombine/blob/main/examples/DeconvolutionTests.ipynb>`_
+  for a walkthrough of the available deconvolution techniques and
+  `deconvolution_experiments.py <https://github.com/radio-astro-tools/uvcombine/blob/main/examples/deconvolution_experiments.py>`_
+  for additional experiments.
 * ``weights`` allows a 2D numpy array matching the high-resolution image size to be used as custom weighting, similar to the ``pbresponse``. This can be used to taper the edges of images to avoid Gibbs ringing.
 
 
 The impact of these many options is explored in depth in `this tutorial <https://github.com/radio-astro-tools/uvcombine/blob/main/examples/FeatheringTests.ipynb>`_.
+For a comparison of this Fourier-space ("uv") approach against a simpler real-space
+linear combination, see `Compare Linear to UV.ipynb <https://github.com/radio-astro-tools/uvcombine/blob/main/examples/Compare%20Linear%20to%20UV.ipynb>`_.
 

--- a/docs/feathering_images.rst
+++ b/docs/feathering_images.rst
@@ -33,5 +33,5 @@ images when combining.
 * ``weights`` allows a 2D numpy array matching the high-resolution image size to be used as custom weighting, similar to the ``pbresponse``. This can be used to taper the edges of images to avoid Gibbs ringing.
 
 
-The impact of these many options is explored in depth in `this tutorial <https://github.com/radio-astro-tools/uvcombine/blob/master/examples/FeatheringTests.ipynb>`_.
+The impact of these many options is explored in depth in `this tutorial <https://github.com/radio-astro-tools/uvcombine/blob/main/examples/FeatheringTests.ipynb>`_.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,7 +8,7 @@ Also included are consistency tests for the flux calibration and single-dish sca
 the data in the uv-overlap range.
 
 Additional examples of the uvcombine functionality can be found in the
-`examples <https://github.com/uvcombine/uvcombine/tree/master/examples>`_ directory.
+`examples <https://github.com/radio-astro-tools/uvcombine/tree/main/examples>`_ directory.
 
 Getting started
 ^^^^^^^^^^^^^^^
@@ -19,6 +19,7 @@ Getting started
    install.rst
    feathering_images.rst
    feathering_cubes.rst
+   diagnostics.rst
    api.rst
 
 radio-astro-tools

--- a/uvcombine/uvcombine.py
+++ b/uvcombine/uvcombine.py
@@ -236,10 +236,11 @@ def feather_simple(hires, lores,
 
     Parameters
     ----------
-    highresfitsfile : str
-        The high-resolution FITS file
-    lowresfitsfile : str
-        The low-resolution (single-dish) FITS file
+    hires : str or `~astropy.io.fits.PrimaryHDU` or `~spectral_cube.Projection`
+        The high-resolution image, as a FITS filename, FITS HDU, or Projection.
+    lores : str or `~astropy.io.fits.PrimaryHDU` or `~spectral_cube.Projection`
+        The low-resolution (single-dish) image, as a FITS filename, FITS HDU,
+        or Projection.
     highresextnum : int
         The extension number to use from the high-res FITS file
     lowresextnum : int
@@ -252,8 +253,8 @@ def feather_simple(hires, lores,
         low- or high-resolution data
     pbresponse : `~numpy.ndarray`
         The primary beam response of the high-resolution data. When given,
-        `highresfitsfile` should **not** be primary-beam corrected.
-        `pbresponse` will be multiplied with `lowresfitsfile`, and the
+        `hires` should **not** be primary-beam corrected.
+        `pbresponse` will be multiplied with `lores`, and the
         feathered image will be divided by `pbresponse` to create the final
         image.
     lowresfwhm : `astropy.units.Quantity`
@@ -416,20 +417,28 @@ def feather_plot(hires, lores,
 
     Parameters
     ----------
-    highresfitsfile : str
-        The high-resolution FITS file
-    lowresfitsfile : str
-        The low-resolution (single-dish) FITS file
+    hires : str or `~astropy.io.fits.PrimaryHDU` or `~spectral_cube.Projection`
+        The high-resolution image, as a FITS filename, FITS HDU, or Projection.
+    lores : str or `~astropy.io.fits.PrimaryHDU` or `~spectral_cube.Projection`
+        The low-resolution (single-dish) image, as a FITS filename, FITS HDU,
+        or Projection.
     highresextnum : int
         The extension number to use from the high-res FITS file
+    lowresextnum : int
+        The extension number to use from the low-res FITS file
     highresscalefactor : float
+        A factor to multiply the high-resolution data by to match the
+        low- or high-resolution data
     lowresscalefactor : float
-        A factor to multiply the high- or low-resolution data by to match the
+        A factor to multiply the low-resolution data by to match the
         low- or high-resolution data
     lowresfwhm : `astropy.units.Quantity`
         The full-width-half-max of the single-dish (low-resolution) beam;
         or the scale at which you want to try to match the low/high resolution
         data
+    lowpassfilterSD : bool or str
+        Re-convolve the SD image with the beam before computing its power
+        spectrum. See `~uvcombine.feather_simple` for details.
     xaxisunit : 'arcsec' or 'lambda'
         The X-axis units.  Either arcseconds (angular scale on the sky)
         or baseline length (lambda)
@@ -443,10 +452,16 @@ def feather_plot(hires, lores,
 
     Returns
     -------
-    combo : image
-        The image of the combined low and high resolution data sets
-    combo_hdu : fits.PrimaryHDU
-        (optional) the image encased in a FITS HDU with the relevant header
+    results : dict
+        Dictionary with the azimuthally-averaged power spectra used to make
+        the plot: ``radius`` and ``radius_as`` (the radial/angular scale
+        axis), ``azimuthally_averaged_kernel`` and
+        ``azimuthally_averaged_inverse_kernel`` (the low- and high-res
+        weighting kernels), ``azimuthally_averaged_low_resolution`` and
+        ``azimuthally_averaged_high_resolution`` (the raw power spectra), and
+        ``azimuthally_averaged_low_res_filtered`` and
+        ``azimuthally_averaged_high_res_filtered`` (the power spectra after
+        applying the feathering kernels).
     """
     # import image_tools
     from turbustat.statistics.psds import pspec
@@ -903,10 +918,11 @@ def feather_compare(hires, lores,
 
     Parameters
     ----------
-    highresfitsfile : str
-        The high-resolution FITS file
-    lowresfitsfile : str
-        The low-resolution (single-dish) FITS file
+    hires : str or `~astropy.io.fits.PrimaryHDU` or `~spectral_cube.Projection`
+        The high-resolution image, as a FITS filename, FITS HDU, or Projection.
+    lores : str or `~astropy.io.fits.PrimaryHDU` or `~spectral_cube.Projection`
+        The low-resolution (single-dish) image, as a FITS filename, FITS HDU,
+        or Projection.
     SAS : `astropy.units.Quantity`
         The smallest angular scale to plot
     LAS : `astropy.units.Quantity`
@@ -1066,10 +1082,11 @@ def angular_range_image_comparison(hires, lores, SAS, LAS, lowresfwhm,
 
     Parameters
     ----------
-    highresfitsfile : str
-        The high-resolution FITS file
-    lowresfitsfile : str
-        The low-resolution (single-dish) FITS file
+    hires : str or `~astropy.io.fits.PrimaryHDU` or `~spectral_cube.Projection`
+        The high-resolution image, as a FITS filename, FITS HDU, or Projection.
+    lores : str or `~astropy.io.fits.PrimaryHDU` or `~spectral_cube.Projection`
+        The low-resolution (single-dish) image, as a FITS filename, FITS HDU,
+        or Projection.
     SAS : `astropy.units.Quantity`
         The smallest angular scale to plot
     LAS : `astropy.units.Quantity`


### PR DESCRIPTION
## Summary
Docs review of the current `main` functions against the Sphinx docs turned up several stale/incomplete spots:

- Two dead example links (`docs/index.rst` pointed at the wrong GitHub org; `docs/feathering_images.rst` pointed at the `master` branch, which no longer exists — the repo default is `main`).
- `docs/feathering_cubes.rst` described the removed `fourier_combine_cubes` function as merely "deprecated" with a live `~uvcombine.fourier_combine_cubes` cross-reference; it was fully removed in the `remove_deprecated` cleanup (#48), so this is now misleading and the link target doesn't exist. Reworded to say it was removed.
- `feather_simple`, `feather_plot`, `feather_compare`, and `angular_range_image_comparison` all documented `highresfitsfile`/`lowresfitsfile` in their `Parameters` sections, but those arguments were renamed to `hires`/`lores` some time ago. Since these render via `automodapi`, the published API reference showed parameter names that don't exist.
- `feather_plot`'s `Returns` docstring was copy-pasted from `feather_simple` and described a `combo` image/HDU; the function actually returns a dict of azimuthally-averaged power-spectrum arrays. Fixed to describe the actual return value.
- `feather_plot` and `feather_compare` were the only two of the four public functions with no narrative usage guide (only reachable via the bare `automodapi` listing) despite `feather_compare` being the uv-overlap consistency check called out in the package's own tagline. Added `docs/diagnostics.rst` covering both.

**Not included**: `feather_plot` has an undeclared runtime dependency on `turbustat` (not listed anywhere in `pyproject.toml`), which will make it fail for most users out of the box. That's a functional bug rather than a docs issue, so it's being tracked separately rather than folded into this docs PR.

## Test plan
- [x] `sphinx-build -W -b html docs <out>` builds clean with warnings-as-errors after these changes (0 warnings).
- [x] Spot-checked the rendered `feather_plot`/`feather_compare` API pages to confirm the corrected docstrings render as intended.
- [x] Parsed `docs/diagnostics.rst`'s doctest-formatted examples with `python -m doctest` to confirm they're syntactically valid.
- [ ] CI docs build on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)