### PR TITLE
Vendor turbustat's pspec function to drop the runtime dependency

### DIFF
--- a/LICENSE.rst
+++ b/LICENSE.rst
@@ -25,3 +25,10 @@ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
 CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Licenses of bundled code
+=========================
+
+``uvcombine/pspec.py`` is adapted from TurbuStat
+(https://github.com/Astroua/TurbuStat), which is distributed under the
+MIT license reproduced at the top of that file.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
 dependencies = [
   "astropy>=6.1",
   "numpy>=1.8",
+  "scipy",
   "packaging>=19",
   "setuptools>=62.3.3",
   "matplotlib>=3.5",

--- a/uvcombine/pspec.py
+++ b/uvcombine/pspec.py
@@ -1,0 +1,244 @@
+# Vendored from TurbuStat (turbustat.statistics.psds), to avoid adding a
+# runtime dependency on the full turbustat package for this one function.
+# https://github.com/Astroua/TurbuStat/blob/master/turbustat/statistics/psds.py
+#
+# Licensed under an MIT open source license:
+#
+# Copyright (c) 2014-2019 TurbuStat Development Team
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to
+# deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+# sell copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+
+import numpy as np
+from scipy.stats import binned_statistic
+import astropy.units as u
+from astropy.coordinates import Angle
+from scipy.stats import t as t_dist
+
+
+def pspec(psd2, nbins=None, return_stddev=False, binsize=1.0,
+          logspacing=True, max_bin=None, min_bin=None, return_freqs=True,
+          theta_0=None, delta_theta=None, boot_iter=None,
+          mean_func=np.nanmean):
+    '''
+    Calculate the radial profile using scipy.stats.binned_statistic.
+
+    Parameters
+    ----------
+    psd2 : np.ndarray
+        2D Spectral power density.
+    nbins : int, optional
+        Number of bins to use. If None, it is calculated based on the size
+        of the given arrays.
+    return_stddev : bool, optional
+        Return the standard deviations in each bin.
+    binsize : float, optional
+        Size of bins to be used. If logspacing is enabled, this will increase
+        the number of bins used by the inverse of the given binsize.
+    logspacing : bool, optional
+        Use logarithmically spaces bins.
+    max_bin : float, optional
+        Give the maximum value to bin to.
+    min_bin : float, optional
+        Give the minimum value to bin to.
+    return_freqs : bool, optional
+        Return spatial frequencies.
+    theta_0 : `~astropy.units.Quantity`, optional
+        The center angle of the azimuthal mask. Must have angular units.
+    delta_theta : `~astropy.units.Quantity`, optional
+        The width of the azimuthal mask. This must be given when
+        a `theta_0` is given. Must have angular units.
+    boot_iter : int, optional
+        Number of bootstrap iterations for estimating the standard deviation
+        in each bin. Require `return_stddev=True`.
+    mean_func : function, optional
+        Define the function used to create the 1D power spectrum. The default
+        is `np.nanmean`.
+
+    Returns
+    -------
+    bins_cents : np.ndarray
+        Centre of the bins.
+    ps1D : np.ndarray
+        1D binned power spectrum.
+    ps1D_stddev : np.ndarray
+        Returned when return_stddev is enabled. Standard deviations
+        within each of the bins.
+    '''
+
+    yy, xx = make_radial_arrays(psd2.shape)
+
+    dists = np.sqrt(yy**2 + xx**2)
+    if theta_0 is not None:
+
+        if delta_theta is None:
+            raise ValueError("Must give delta_theta.")
+
+        theta_0 = theta_0.to(u.rad)
+        delta_theta = delta_theta.to(u.rad)
+
+        theta_limits = Angle([theta_0 - 0.5 * delta_theta,
+                              theta_0 + 0.5 * delta_theta])
+
+        # Define theta array
+        thetas = Angle(np.arctan2(yy, xx) * u.rad)
+
+        # Wrap around pi
+        theta_limits = theta_limits.wrap_at(np.pi * u.rad)
+
+    if nbins is None:
+        nbins = int(np.round(dists.max() / binsize) + 1)
+
+    if return_freqs:
+        yy_freq, xx_freq = make_radial_freq_arrays(psd2.shape)
+
+        freqs_dist = np.sqrt(yy_freq**2 + xx_freq**2)
+
+        zero_freq_val = freqs_dist[np.nonzero(freqs_dist)].min() / 2.
+        freqs_dist[freqs_dist == 0] = zero_freq_val
+
+    if max_bin is None:
+        if return_freqs:
+            max_bin = 0.5
+        else:
+            max_bin = dists.max()
+
+    if min_bin is None:
+        if return_freqs:
+            min_bin = 1.0 / min(psd2.shape)
+        else:
+            min_bin = 0.5
+
+    if logspacing:
+        bins = np.logspace(np.log10(min_bin), np.log10(max_bin), nbins + 1)
+    else:
+        bins = np.linspace(min_bin, max_bin, nbins + 1)
+
+    if return_freqs:
+        dist_arr = freqs_dist
+    else:
+        dist_arr = dists
+
+    if theta_0 is not None:
+        if theta_limits[0] < theta_limits[1]:
+            azim_mask = np.logical_and(thetas >= theta_limits[0],
+                                       thetas <= theta_limits[1])
+        else:
+            azim_mask = np.logical_or(thetas >= theta_limits[0],
+                                      thetas <= theta_limits[1])
+
+        azim_mask = np.logical_or(azim_mask, azim_mask[::-1, ::-1])
+
+        # Fill in the middle angles
+        ny = np.floor(psd2.shape[0] / 2.).astype(int)
+        nx = np.floor(psd2.shape[1] / 2.).astype(int)
+
+        azim_mask[ny - 1:ny + 1, nx - 1:nx + 1] = True
+    else:
+        azim_mask = None
+
+    finite_mask = np.isfinite(psd2)
+    if azim_mask is not None:
+        finite_mask = np.logical_and(finite_mask, azim_mask)
+
+    ps1D, bin_edge, cts = binned_statistic(dist_arr[finite_mask].ravel(),
+                                           psd2[finite_mask].ravel(),
+                                           bins=bins,
+                                           statistic=mean_func)
+
+    bin_cents = (bin_edge[1:] + bin_edge[:-1]) / 2.
+
+    if not return_stddev:
+        if theta_0 is not None:
+            return bin_cents, ps1D, azim_mask
+        else:
+            return bin_cents, ps1D
+    else:
+
+        if boot_iter is None:
+
+            stat_func = lambda x: np.nanstd(x, ddof=1)
+
+        else:
+            from astropy.stats import bootstrap
+
+            stat_func = lambda data: np.mean(bootstrap(data, boot_iter,
+                                                       bootfunc=np.std))
+
+        ps1D_stddev = binned_statistic(dist_arr[finite_mask].ravel(),
+                                       psd2[finite_mask].ravel(),
+                                       bins=bins,
+                                       statistic=stat_func)[0]
+
+        # We're dealing with variations in the number of samples for each bin.
+        # Add a correction based on the t distribution
+        bin_cts = binned_statistic(dist_arr[finite_mask].ravel(),
+                                   psd2[finite_mask].ravel(),
+                                   bins=bins,
+                                   statistic='count')[0]
+
+        # Two-tail CI for 85% (~1 sigma)
+        alpha = 1 - (0.15 / 2.)
+
+        # Correction factor to convert to the standard error
+        A = t_dist.ppf(alpha, bin_cts - 1) / np.sqrt(bin_cts)
+
+        # If the standard error is larger than the standard deviation,
+        # use it instead
+        ps1D_stddev[A > 1] *= A[A > 1]
+
+        # Mask out bins that have 1 or fewer points
+        mask = bin_cts <= 1
+
+        ps1D_stddev[mask] = np.nan
+        ps1D[mask] = np.nan
+
+        if theta_0 is not None:
+            return bin_cents, ps1D, ps1D_stddev, azim_mask
+        else:
+            return bin_cents, ps1D, ps1D_stddev
+
+
+def make_radial_arrays(shape, y_center=None, x_center=None):
+
+    if y_center is None:
+        y_center = np.floor(shape[0] / 2.).astype(int)
+    else:
+        y_center = int(y_center)
+
+    if x_center is None:
+        x_center = np.floor(shape[1] / 2.).astype(int)
+    else:
+        x_center = int(x_center)
+
+    y = np.arange(-y_center, shape[0] - y_center)
+    x = np.arange(-x_center, shape[1] - x_center)
+
+    yy, xx = np.meshgrid(y, x, indexing='ij')
+
+    return yy, xx
+
+
+def make_radial_freq_arrays(shape):
+
+    yfreqs = np.fft.fftshift(np.fft.fftfreq(shape[0]))
+    xfreqs = np.fft.fftshift(np.fft.fftfreq(shape[1]))
+
+    yy_freq, xx_freq = np.meshgrid(yfreqs, xfreqs, indexing='ij')
+
+    return yy_freq[::-1], xx_freq[::-1]

--- a/uvcombine/uvcombine.py
+++ b/uvcombine/uvcombine.py
@@ -14,6 +14,8 @@ from astropy import stats
 from astropy.convolution import convolve_fft, Gaussian2DKernel
 from spectral_cube.dask_spectral_cube import DaskSpectralCube, DaskVaryingResolutionSpectralCube
 
+from .pspec import pspec
+
 
 def _plot_axis_limits(xaxis, arg_xmin):
     """Return numeric plot limits for unitless or Quantity-like axes."""
@@ -463,9 +465,6 @@ def feather_plot(hires, lores,
         ``azimuthally_averaged_high_res_filtered`` (the power spectra after
         applying the feathering kernels).
     """
-    # import image_tools
-    from turbustat.statistics.psds import pspec
-
     if isinstance(hires, str):
         hdu_hi = fits.open(hires)[highresextnum]
         proj_hi = Projection.from_hdu(hdu_hi)


### PR DESCRIPTION
## Summary
`feather_plot` did `from turbustat.statistics.psds import pspec` inside its body, but `turbustat` was never declared as a dependency anywhere in `pyproject.toml` (not even as an optional extra) and isn't mentioned in the docs. Any user calling this documented, public function hit `ModuleNotFoundError` unless they happened to already have turbustat installed. There's also no test coverage for `feather_plot`, so this had gone unnoticed.

Rather than pull in the full `turbustat` package as a dependency for one function, this vendors `pspec()` (and its two small helper functions `make_radial_arrays`/`make_radial_freq_arrays`) into a new `uvcombine/pspec.py`, copied verbatim from [`turbustat/statistics/psds.py`](https://github.com/Astroua/TurbuStat/blob/master/turbustat/statistics/psds.py). The vendored code only needs numpy, scipy, and astropy — all either already required or (in scipy's case) already relied on transitively via `scale_factor.py` without being declared, so `scipy` is now added explicitly to `dependencies` in `pyproject.toml`.

The original MIT license and copyright notice are preserved in full at the top of `uvcombine/pspec.py`, with a pointer added in `LICENSE.rst` noting that one file carries a different (MIT) license from the rest of the package (BSD-3-Clause).

`feather_plot`'s `import` is moved from a lazy in-function import to a normal top-of-module import in `uvcombine/uvcombine.py`, since the vendored dependency no longer needs to be optional.

## Test plan
- [x] `pytest --pyargs uvcombine` — 32 passed, 7 skipped (turbustat not installed in the test environment).
- [x] Ran `feather_plot` end-to-end against synthetic test data (`generate_testing_data`) with `turbustat` confirmed absent from the environment; it completes and returns the expected dict of power-spectrum arrays.
- [x] `python -c "from uvcombine.pspec import pspec"` and a standalone call against a random 2D array to confirm the module works in isolation.
- [x] CI run on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)